### PR TITLE
Provide ability to use existing EIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ output "public_subnets_by_type" {
 
 | Variable                                   | Type            | Required | Default                      | Description                                                                                         |
 |--------------------------------------------|-----------------|----------|------------------------------|-----------------------------------------------------------------------------------------------------|
-| **`tags_default`**                         | `map(string)`   | No       | `{}`                         | (Optional) Default tags to assign across all resources created by the module.                         |
+| **`tags_default`**                         | `map(string)`   | No       | `{}`                         | (Optional) Default tags to assign across all resources created by the module.                       |
+| **`existing_eip_ids_az`**                  | `map(string)`   | No       | `{}`                         | (Optional) Map of Availability Zones (AZ) to existing Elastic IP (EIP) IDs for NAT Gateways.        |
 
 ## Output
 

--- a/examples/nat_gateway_az_existing_eip/README.md
+++ b/examples/nat_gateway_az_existing_eip/README.md
@@ -1,0 +1,2 @@
+# NAT Gateway setup with one NAT Gateway per Availability Zone (AZ),
+# and an existing Elastic IP (EIP) for each NAT Gateway.

--- a/examples/nat_gateway_az_existing_eip/main.tf
+++ b/examples/nat_gateway_az_existing_eip/main.tf
@@ -1,0 +1,193 @@
+provider "aws" {
+  region = "us-west-1"
+}
+
+module "vpc" {
+  source = "ViktorUJ/vpc/aws"
+  # Using existing EIP IDs here
+  existing_eip_ids_az = {
+    "us-west-1a" = "vpc-0a1b2c3d4e5f6g7h8"
+    "us-east-1b" = "vpc-0a1b2c3d4e5f6g7h8"
+  }
+  vpc = {
+    name                  = "main"
+    cidr                  = "10.2.0.0/16"
+    secondary_cidr_blocks = ["100.64.0.0/16"]
+    instance_tenancy      = "default"
+    enable_dns_support    = true
+    enable_dns_hostnames  = false
+    tags_default = {
+      "Environment" = "Dev"
+      "Name"        = "EKS-VPC"
+      "Owner"       = "DevOps"
+    }
+    dhcp_options = {
+      domain_name          = ""
+      domain_name_servers  = []
+      ntp_servers          = []
+      netbios_name_servers = []
+      netbios_node_type    = ""
+    }
+  }
+
+  subnets = {
+    public = {
+      public1 = {
+        name                                           = "public-1"
+        cidr                                           = "10.2.2.0/24"
+        az                                             = "us-west-1a"
+        tags                                           = { "Name" = "public-1" }
+        type                                           = "public"
+        assign_ipv6_address_on_creation                = false
+        customer_owned_ipv4_pool                       = ""
+        enable_dns64                                   = false
+        enable_resource_name_dns_aaaa_record_on_launch = false
+        enable_resource_name_dns_a_record_on_launch    = false
+        ipv6_native                                    = false
+        map_customer_owned_ip_on_launch                = false
+        map_public_ip_on_launch                        = true
+        outpost_arn                                    = ""
+        private_dns_hostname_type_on_launch            = "ip-name"
+        nacl = {
+          default_ingress = {
+            egress      = false
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+          default_egress = {
+            egress      = true
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+        }
+      }
+      public2 = {
+        name                                           = "public-2"
+        cidr                                           = "10.2.3.0/24"
+        az                                             = "us-west-1b"
+        tags                                           = { "Name" = "public-2" }
+        type                                           = "public"
+        assign_ipv6_address_on_creation                = false
+        customer_owned_ipv4_pool                       = ""
+        enable_dns64                                   = false
+        enable_resource_name_dns_aaaa_record_on_launch = false
+        enable_resource_name_dns_a_record_on_launch    = false
+        ipv6_native                                    = false
+        map_customer_owned_ip_on_launch                = false
+        map_public_ip_on_launch                        = true
+        outpost_arn                                    = ""
+        private_dns_hostname_type_on_launch            = "ip-name"
+        nacl = {
+          default_ingress = {
+            egress      = false
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+          default_egress = {
+            egress      = true
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+        }
+      }
+    }
+    private = {
+      eks1 = {
+        name                                           = "eks-control-plane-1"
+        cidr                                           = "10.2.0.0/24"
+        az                                             = "us-west-1a"
+        tags                                           = {}
+        type                                           = "private"
+        assign_ipv6_address_on_creation                = false
+        customer_owned_ipv4_pool                       = ""
+        enable_dns64                                   = false
+        enable_resource_name_dns_aaaa_record_on_launch = false
+        enable_resource_name_dns_a_record_on_launch    = false
+        ipv6_native                                    = false
+        map_customer_owned_ip_on_launch                = false
+        map_public_ip_on_launch                        = false
+        outpost_arn                                    = ""
+        private_dns_hostname_type_on_launch            = "ip-name"
+        nacl = {
+          eks_default_ingress = {
+            egress      = false
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+          eks_default_egress = {
+            egress      = true
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+        }
+      }
+      eks2 = {
+        name                                           = "elk-control-plane-2"
+        cidr                                           = "10.2.1.0/24"
+        az                                             = "us-west-1b"
+        tags                                           = {}
+        type                                           = "private"
+        assign_ipv6_address_on_creation                = false
+        customer_owned_ipv4_pool                       = ""
+        enable_dns64                                   = false
+        enable_resource_name_dns_aaaa_record_on_launch = false
+        enable_resource_name_dns_a_record_on_launch    = false
+        ipv6_native                                    = false
+        map_customer_owned_ip_on_launch                = false
+        map_public_ip_on_launch                        = false
+        outpost_arn                                    = ""
+        private_dns_hostname_type_on_launch            = "ip-name"
+        nacl = {
+          eks_default_ingress = {
+            egress      = false
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+          eks_default_egress = {
+            egress      = true
+            rule_number = 100
+            rule_action = "allow"
+            from_port   = 0
+            to_port     = 0
+            protocol    = "-1"
+            cidr_block  = "0.0.0.0/0"
+          }
+        }
+      }
+    }
+  }
+
+  tags_default = {
+    "Environment" = "Dev"
+    "Name"        = "EKS-VPC"
+    "Owner"       = "DevOps"
+  }
+}

--- a/examples/nat_gateway_az_existing_eip/output.tf
+++ b/examples/nat_gateway_az_existing_eip/output.tf
@@ -1,0 +1,3 @@
+output "nat_gateway_az_raw" {
+  value = module.vpc.nat_gateway_az_raw
+}

--- a/subnets_private.tf
+++ b/subnets_private.tf
@@ -60,15 +60,17 @@ locals {
 resource "aws_nat_gateway" "az_nat_gateway" {
   for_each = local.private_subnets_by_az
 
-  allocation_id = aws_eip.az_nat_gateway_eip[each.key].id
+  allocation_id = length(keys(var.existing_eip_ids_az)) == 0 ? aws_eip.az_nat_gateway_eip[each.key].id : var.existing_eip_ids_az[each.key]
   subnet_id     = local.public_subnets_by_az_output[each.key][0]
   tags          = merge(var.tags_default, { "Name" = "az_nat_gateway-${each.key}" })
 }
 
 resource "aws_eip" "az_nat_gateway_eip" {
-  for_each = local.private_subnets_by_az
-  tags     = merge(var.tags_default, { "Name" = "az_nat_gateway-${each.key}" })
-  domain   = "vpc"
+  for_each = length(keys(var.existing_eip_ids_az)) == 0 ? {
+    for az, data in local.private_subnets_by_az : az => az
+  } : {}
+  domain = "vpc"
+  tags   = merge(var.tags_default, { "Name" = "az_nat_gateway-${each.key}" })
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -178,6 +178,24 @@ variable "subnets" {
     ])
     error_message = "Invalid value for private_dns_hostname_type_on_launch. Must be one of: ip-name, resource-name."
   }
+}
 
+variable "existing_eip_ids_az" {
+  description = "A map of existing Elastic IPs IDs to associate with the NAT Gateways where key is the AZ, value is the EIP ID"
+  type        = map(string)
+  default     = {}
 
+  validation {
+    condition = alltrue([
+      for az, eip in var.existing_eip_ids_az : can(regex("^eipalloc-[0-9a-fA-F]{17}$", eip))
+    ])
+    error_message = "Each value in existing_eip_ids_az must be a valid Elastic IP ID (eipalloc-xxxxxxxxxxxxxxxxx)."
+  }
+
+  validation {
+    condition = alltrue([
+      for az, eip in var.existing_eip_ids_az : can(regex("^[a-z]{2}-[a-z]+-[0-9]{1}[a-z]$", az))
+    ])
+    error_message = "Each key in existing_eip_ids_az must be a valid Availability Zone (e.g., eu-west-1a)."
+  }
 }


### PR DESCRIPTION
First of all thanks for the module. 
I have feature request to add the ability to use existing EIP ids.
Please let me know if it's possible to add this feature.

Why?
We have a use case where we have to use existing EIPs for NAT gateways.
There's no option to create new EIPs for NAT gateways in our environment, so we have to use existing EIPs.

What?
Add the ability to use existing EIP ids for NAT gateways.